### PR TITLE
 feat: endpoint added (/api/v1/interest), prividing news summary

### DIFF
--- a/internal/handler/root.go
+++ b/internal/handler/root.go
@@ -53,7 +53,7 @@ func (h *Handler) GetInterestDetail(c *gin.Context) {
 		return
 	}
 	if category == "news" {
-		h.GetNewsList(c)
+		h.GetNewsDetails(c)
 		return
 	}
 }
@@ -87,9 +87,9 @@ func (h *Handler) GetRealtimeSearchDetail(c *gin.Context) {
 	})
 }
 
-// News 목록 조회
-func (h *Handler) GetNewsList(c *gin.Context) {
-	news, err := h.dashboardService.GetNewsList()
+// News 상세 목록 조회
+func (h *Handler) GetNewsDetails(c *gin.Context) {
+	news, err := h.dashboardService.GetNewsDetails()
 	if err != nil {
 		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
 		return
@@ -98,5 +98,19 @@ func (h *Handler) GetNewsList(c *gin.Context) {
 	h.okResponse(c, model.NewsResponse{
 		ApiResponse: pkg.NewApiResponse("SUCCESS"),
 		News:        news,
+	})
+}
+
+// News 요약 조회
+func (h *Handler) GetNewsSummary(c *gin.Context) {
+	summaries, err := h.dashboardService.GetNewsSummary()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.NewsSummaryResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		NewsSummary: summaries,
 	})
 }

--- a/internal/handler/root.go
+++ b/internal/handler/root.go
@@ -51,8 +51,7 @@ func (h *Handler) GetInterestDetail(c *gin.Context) {
 	} else if category == "realtime-search" {
 		h.GetRealtimeSearchDetail(c)
 		return
-	}
-	if category == "news" {
+	} else if category == "news" {
 		h.GetNewsDetails(c)
 		return
 	}

--- a/internal/model/news.go
+++ b/internal/model/news.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/bestkkii/saedori-api-server/pkg"
-	"go.mongodb.org/mongo-driver/bson/primitive" // 오늘의 단어
 )
 
 // FastAPI 응답을 위한 모델
@@ -79,4 +78,15 @@ func ProcessNewsKeywords(newsItems []NewsItem) []string {
 	}
 	
 	return keywords
+}
+
+// 뉴스 요약 응답을 위한 모델
+type NewsSummary struct {
+	Company string `json:"company"`
+	Title   string `json:"title"`
+}
+
+type NewsSummaryResponse struct {
+	*pkg.ApiResponse
+	NewsSummary []NewsSummary `json:"news_summary" binding:"required"`
 }

--- a/internal/repository/dashboard.go
+++ b/internal/repository/dashboard.go
@@ -155,7 +155,7 @@ func (d *DashboardRepository) GetRealtimeSearchesByCountry(ctx context.Context, 
     return results, nil
 }
 
-func (d *DashboardRepository) GetNews() ([]*model.News, error) {
+func (d *DashboardRepository) GetNewsDetails() ([]*model.News, error) {
 	collection := d.getCollection("News")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -182,4 +182,22 @@ func (d *DashboardRepository) GetNews() ([]*model.News, error) {
 	}
 
 	return news, nil
+}
+
+func (d *DashboardRepository) GetNewsSummary() (*model.News, error) {
+	collection := d.getCollection("News")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// created_at 인덱스를 활용하여 최신 데이터 조회
+	opts := options.FindOne().SetSort(bson.D{{Key: "created_at", Value: -1}})
+	
+	var news model.News
+	err := collection.FindOne(ctx, bson.M{}, opts).Decode(&news)
+	if err != nil {
+		fmt.Println("Error getting latest news:", err)
+		return nil, err
+	}
+
+	return &news, nil
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,6 +19,7 @@ func NewRouter(service *service.Service) *Router {
 	apiV1 := r.engine.Group("/api/v1")
 
 	apiV1.GET("/keywords", h.GetKeywordList)
+	apiV1.GET("/interest", h.GetNewsSummary)
 	apiV1.GET("/interest/detail", h.GetInterestDetail)
 	return r
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,7 +19,7 @@ func NewRouter(service *service.Service) *Router {
 	apiV1 := r.engine.Group("/api/v1")
 
 	apiV1.GET("/keywords", h.GetKeywordList)
-	apiV1.GET("/interest", h.GetNewsSummary)
+	// apiV1.GET("/interest", h.어쩌구저쩌구)
 	apiV1.GET("/interest/detail", h.GetInterestDetail)
 	return r
 }


### PR DESCRIPTION
**feat**
- 뉴스 요약, 상세 내용을 Dash에 전달하는 기능 추가

**fix**
- 첫번째 fix : (handler/root.go의 GetInterestDetail) 관분 상세조회할 때 사용하는 api "/api/v1/interest/detail?category={}"에서 news의 if 문 수정
- 두번째 fix : 모든 컨텐츠 요약화면 보여주기 ("/api/v1/interest")의 endpoint 추가했다가 주석처리.