### PR TITLE
 feat: send keywords to Dash

### DIFF
--- a/internal/handler/root.go
+++ b/internal/handler/root.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"net/http"
 	"sync"
 
 	"github.com/bestkkii/saedori-api-server/internal/model"

--- a/internal/handler/root.go
+++ b/internal/handler/root.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"sync"
 
 	"github.com/bestkkii/saedori-api-server/internal/model"

--- a/internal/model/keyword.go
+++ b/internal/model/keyword.go
@@ -5,13 +5,21 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// MongoDB Document 구조체
 type Keyword struct {
-	ID           primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	Top3Keywords []string           `bson:"top3_keywords" json:"top3_keywords" binding:"required"`
-	CreatedAt    int64              `bson:"created_at" json:"created_at" binding:"required"`
+	// ID        primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	CreatedAt int64    `bson:"created_at" json:"created_at"`
+	Keyword   []string `bson:"keyword" json:"keyword"`
+	Category  string   `bson:"category" json:"category"`
+}
+
+// API 응답 구조체
+type KeywordResponse struct {
+	Category string   `json:"category"`
+	Keyword  []string `json:"keyword"`
 }
 
 type GetKeywordListResponse struct {
 	*pkg.ApiResponse
-	Keywords []*Keyword `json:"result"`
+	Keywords []KeywordResponse `json:"top3_keywords"`
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,6 +19,7 @@ func NewRouter(service *service.Service) *Router {
 	apiV1 := r.engine.Group("/api/v1")
 
 	apiV1.GET("/keywords", h.GetKeywordList)
+	apiV1.GET("/keyword/top3", h.GetKeywordList)
 	// apiV1.GET("/interest", h.어쩌구저쩌구)
 	apiV1.GET("/interest/detail", h.GetInterestDetail)
 	return r


### PR DESCRIPTION
**feat**
오늘의 단어를 Gin → Dash로 전달하는 기능입니다
api : "/api/v1/keyword/top3"

**fix**
MongoDB에 저장된 Keyword Collection의 양식에 맞게 수정
사용하지 않는 import 제거