### PR TITLE
feat: add API to get full interest summary information

### DIFF
--- a/internal/handler/non_query.go
+++ b/internal/handler/non_query.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"github.com/bestkkii/saedori-api-server/internal/model"
+	"github.com/bestkkii/saedori-api-server/pkg"
+	"github.com/gin-gonic/gin"
+)
+
+/**
+* 쿼리 스트링 없는 API 리스트
+**/
+
+// Top3 Keyword 목록 조회
+func (h *Handler) GetKeywordList(c *gin.Context) {
+	keywords, err := h.dashboardService.GetKeywordList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.GetKeywordListResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		Keywords:    keywords,
+	})
+}
+
+// Music 순위 조회
+func (h *Handler) GetMusicList(c *gin.Context) {
+	musics, err := h.dashboardService.GetMusicList()
+
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.MusicResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		Musics:      musics,
+	})
+}
+
+func (h *Handler) GetRealtimeSearchDetail(c *gin.Context) {
+	realtimeSearchDetail, err := h.dashboardService.GetRealtimeSearchDetailList()
+
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.RealtimeSearchDetailResponse{
+		ApiResponse:                 pkg.NewApiResponse("SUCCESS"),
+		RealtimeSearchDetailWrapper: realtimeSearchDetail.RealtimeSearchDetailWrapper,
+	})
+}
+
+// News 상세 목록 조회
+func (h *Handler) GetNewsDetails(c *gin.Context) {
+	news, err := h.dashboardService.GetNewsDetails()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.NewsResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		News:        news,
+	})
+}
+
+// News 요약 조회
+func (h *Handler) GetNewsSummary(c *gin.Context) {
+	summaries, err := h.dashboardService.GetNewsSummary()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.NewsSummaryResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		NewsSummary: summaries,
+	})
+}

--- a/internal/handler/query.go
+++ b/internal/handler/query.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"github.com/bestkkii/saedori-api-server/internal/model"
+	"github.com/bestkkii/saedori-api-server/pkg"
+	"github.com/gin-gonic/gin"
+)
+
+/**
+* 쿼리 스트링 있는 API 리스트
+**/
+
+func (h *Handler) GetInterestDetail(c *gin.Context) {
+	category := c.DefaultQuery("category", "default_category")
+	parsedCategories, length := pkg.ParseCategory(category)
+
+	switch length {
+	case 1:
+		h.handleSingleCategory(c, parsedCategories[0])
+	case 2:
+		h.handleDoubleCategories(c, parsedCategories)
+	default:
+		h.handleAllCategories(c, parsedCategories)
+	}
+}
+
+func (h *Handler) handleSingleCategory(c *gin.Context, category string) {
+	switch category {
+	case "music":
+		h.GetMusicList(c)
+	case "realtime-search":
+		h.GetRealtimeSearchDetail(c)
+	case "news":
+		h.GetNewsDetails(c)
+	}
+}
+
+func (h *Handler) handleDoubleCategories(c *gin.Context, categories []string) {
+	switch {
+	case categories[0] == "music" && categories[1] == "news":
+		h.GetMusicAndNews(c)
+	case categories[0] == "music" && categories[1] == "realtime-search":
+		h.GetMusicAndRealtimeSearch(c)
+	case categories[0] == "news" && categories[1] == "realtime-search":
+		h.GetNewsAndRealtimeSearch(c)
+	}
+}
+
+func (h *Handler) handleAllCategories(c *gin.Context, categories []string) {
+	if categories[0] == "music" && categories[1] == "news" && categories[2] == "realtime-search" {
+		h.GetAllCategories(c)
+	}
+}
+
+func (h *Handler) GetMusicAndNews(c *gin.Context) {
+	musics, err := h.dashboardService.GetMusicList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	news, err := h.dashboardService.GetNewsDetails()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.AllCategoriesResponse{
+		ApiResponse: pkg.NewApiResponse("SUCCESS"),
+		Musics:      musics,
+		News:        news,
+	})
+}
+
+func (h *Handler) GetMusicAndRealtimeSearch(c *gin.Context) {
+	musics, err := h.dashboardService.GetMusicList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	realtimeSearchDetail, err := h.dashboardService.GetRealtimeSearchDetailList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.AllCategoriesResponse{
+		ApiResponse:                 pkg.NewApiResponse("SUCCESS"),
+		Musics:                      musics,
+		RealtimeSearchDetailWrapper: realtimeSearchDetail.RealtimeSearchDetailWrapper,
+	})
+}
+
+func (h *Handler) GetNewsAndRealtimeSearch(c *gin.Context) {
+	news, err := h.dashboardService.GetNewsDetails()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	realtimeSearchDetail, err := h.dashboardService.GetRealtimeSearchDetailList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.AllCategoriesResponse{
+		ApiResponse:                 pkg.NewApiResponse("SUCCESS"),
+		RealtimeSearchDetailWrapper: realtimeSearchDetail.RealtimeSearchDetailWrapper,
+		News:                        news,
+	})
+}
+
+func (h *Handler) GetAllCategories(c *gin.Context) {
+	musics, err := h.dashboardService.GetMusicList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	realtimeSearchDetail, err := h.dashboardService.GetRealtimeSearchDetailList()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	news, err := h.dashboardService.GetNewsDetails()
+	if err != nil {
+		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
+		return
+	}
+
+	h.okResponse(c, model.AllCategoriesResponse{
+		ApiResponse:                 pkg.NewApiResponse("SUCCESS"),
+		Musics:                      musics,
+		RealtimeSearchDetailWrapper: realtimeSearchDetail.RealtimeSearchDetailWrapper,
+		News:                        news,
+	})
+}

--- a/internal/handler/root.go
+++ b/internal/handler/root.go
@@ -3,10 +3,7 @@ package handler
 import (
 	"sync"
 
-	"github.com/bestkkii/saedori-api-server/internal/model"
 	"github.com/bestkkii/saedori-api-server/internal/service"
-	"github.com/bestkkii/saedori-api-server/pkg"
-	"github.com/gin-gonic/gin"
 )
 
 var (
@@ -25,91 +22,4 @@ func NewHandler(dashboardService *service.Dashboard) *Handler {
 		}
 	})
 	return handlerInstance
-}
-
-// Top3 Keyword 목록 조회
-func (h *Handler) GetKeywordList(c *gin.Context) {
-	keywords, err := h.dashboardService.GetKeywordList()
-	if err != nil {
-		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
-		return
-	}
-
-	h.okResponse(c, model.GetKeywordListResponse{
-		ApiResponse: pkg.NewApiResponse("SUCCESS"),
-		Keywords:    keywords,
-	})
-}
-
-// 관심사 분야 쿼리 파라미터 매칭
-func (h *Handler) GetInterestDetail(c *gin.Context) {
-	category := c.DefaultQuery("category", "default_category")
-
-	if category == "music" {
-		h.GetMusicList(c)
-		return
-	} else if category == "realtime-search" {
-		h.GetRealtimeSearchDetail(c)
-		return
-	} else if category == "news" {
-		h.GetNewsDetails(c)
-		return
-	}
-}
-
-// Music 순위 조회
-func (h *Handler) GetMusicList(c *gin.Context) {
-	musics, err := h.dashboardService.GetMusicList()
-
-	if err != nil {
-		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
-		return
-	}
-
-	h.okResponse(c, model.MusicResponse{
-		ApiResponse: pkg.NewApiResponse("SUCCESS"),
-		Musics:   musics,
-	})
-}
-
-func (h *Handler) GetRealtimeSearchDetail(c *gin.Context) {
-	realtimeSearchDetail, err := h.dashboardService.GetRealtimeSearchDetailList()
-
-	if err != nil {
-		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
-		return
-	}
-
-	h.okResponse(c, model.RealtimeSearchDetailResponse{
-		ApiResponse: pkg.NewApiResponse("SUCCESS"),
-		RealtimeSearchDetailWrapper: realtimeSearchDetail.RealtimeSearchDetailWrapper,
-	})
-}
-
-// News 상세 목록 조회
-func (h *Handler) GetNewsDetails(c *gin.Context) {
-	news, err := h.dashboardService.GetNewsDetails()
-	if err != nil {
-		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
-		return
-	}
-
-	h.okResponse(c, model.NewsResponse{
-		ApiResponse: pkg.NewApiResponse("SUCCESS"),
-		News:        news,
-	})
-}
-
-// News 요약 조회
-func (h *Handler) GetNewsSummary(c *gin.Context) {
-	summaries, err := h.dashboardService.GetNewsSummary()
-	if err != nil {
-		h.failedResponse(c, pkg.NewApiResponse("FAILED"))
-		return
-	}
-
-	h.okResponse(c, model.NewsSummaryResponse{
-		ApiResponse: pkg.NewApiResponse("SUCCESS"),
-		NewsSummary: summaries,
-	})
 }

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -1,0 +1,10 @@
+package model
+
+import "github.com/bestkkii/saedori-api-server/pkg"
+
+type AllCategoriesResponse struct {
+	*pkg.ApiResponse
+	Musics                      []*Music                    `json:"music_summary"`
+	RealtimeSearchDetailWrapper RealtimeSearchDetailWrapper `json:"realtime_search_summary"`
+	News                        []*News                     `json:"news_summary"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,7 +19,6 @@ func NewRouter(service *service.Service) *Router {
 	apiV1 := r.engine.Group("/api/v1")
 
 	apiV1.GET("/keywords", h.GetKeywordList)
-	// apiV1.GET("/interest", h.어쩌구저쩌구)
 	apiV1.GET("/interest/detail", h.GetInterestDetail)
 	return r
 }

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -1,0 +1,12 @@
+package pkg
+
+import (
+	"sort"
+	"strings"
+)
+
+func ParseCategory(category string) ([]string, int) {
+	parsedCategories := strings.Split(category, ",")
+	sort.Strings(parsedCategories)
+	return parsedCategories, len(parsedCategories)
+}


### PR DESCRIPTION
- 전체 요약 정보 조회 API 추가
- handler 파일 분리 (query, non_query)
  - query: 쿼리 스트링이 있는 API (복수 컨텐츠 조회)
  - non-query: 쿼리 스트링이 없는 API (단일 컨텐츠 조회)